### PR TITLE
Use pkg-config instead of system-deps

### DIFF
--- a/crates/dqlite_sys/Cargo.toml
+++ b/crates/dqlite_sys/Cargo.toml
@@ -7,7 +7,4 @@ links = "dqlite"
 
 [build-dependencies]
 bindgen = { version = "0.69.4", default-features = false }
-system-deps = "6.2.2"
-
-[package.metadata.system-deps]
-dqlite = "1.16.0"
+pkg-config = "0.3.30"

--- a/crates/dqlite_sys/build.rs
+++ b/crates/dqlite_sys/build.rs
@@ -1,9 +1,7 @@
 use std::path::PathBuf;
 
 fn main() {
-    let deps = system_deps::Config::new().probe().unwrap();
-    let dqlite = deps.get_by_name("dqlite").unwrap();
-
+    let dqlite = pkg_config::Config::new().atleast_version("1.16.0").probe("dqlite").unwrap();
     let includes = dqlite.include_paths.iter().map(|path| format!("-I{}", path.to_str().unwrap()));
 
     let bindings = bindgen::builder()


### PR DESCRIPTION
system-deps is cool and all but it adds a bunch of stuff to the dependency tree for not much value. pkg-config does everything we need and has no dependencies (and system-deps uses it under the hood so there is no behavior change).